### PR TITLE
Fixed deprecation warning

### DIFF
--- a/gits
+++ b/gits
@@ -1125,7 +1125,7 @@ sub releasecheck($@)
       push(@stashed, $repo);
       $unclean = 1;
       # strip out previous commit from WIP stashes (messages are misleading)
-      $stashes =~ s/^(stash\@{\d+}: )WIP( on .*: [\da-f]+)\.\.\..*$/${1}Work-in-Progress${2}/mg;
+      $stashes =~ s/^(stash\@\{\d+}: )WIP( on .*: [\da-f]+)\.\.\..*$/${1}Work-in-Progress${2}/mg;
       $msg .= $stashes;
     }
 


### PR DESCRIPTION
Fixed an ugly deprecation warning on Ubuntu Xenial.

Unescaped left brace in regex is deprecated, passed through in regex;
  marked by <-- HERE in m/^(stash\@{ <-- HERE \d+}: )WIP( on ._:
  [\da-f]+)...._$/ at /tmp/gits line 1128.
